### PR TITLE
Enhance mobile usability of the mind map application

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,6 +464,15 @@
             .zoom-controls { bottom: 12px; right: 12px; }
             .zoom-btn { width: 36px; height: 36px; }
             .help-content { max-height: 85vh; }
+
+            .help-content .examples-section button.btn-outline {
+                padding: 6px 10px; /* More proportional padding for 12px font */
+            }
+
+            /* Reduce padding for buttons in controls bar on mobile */
+            .controls-container .control-group button.btn-outline {
+                padding: 6px 10px;
+            }
         }
 
         /* ダークモード */
@@ -917,6 +926,22 @@
                     // クリック時のアクション (テキストをクリップボードにコピー)
                     node.addEventListener('click', function(e) {
                         e.stopPropagation(); // 親要素へのイベント伝播を停止
+
+                        // --- BEGIN INLINED TOOLTIP DISPLAY LOGIC (from mouseenter) ---
+                        if (node.dataset.fullText && node.dataset.fullText !== node.textContent) {
+                            tooltip.textContent = node.dataset.fullText;
+
+                            const nodeRect = node.getBoundingClientRect();
+                            const containerRect = mindmapContainer.getBoundingClientRect();
+
+                            tooltip.style.left = `${nodeRect.left - containerRect.left + nodeRect.width / 2}px`;
+                            tooltip.style.top = `${nodeRect.top - containerRect.top}px`;
+                            tooltip.style.transform = 'translate(-50%, calc(-100% - 5px))`;
+                            tooltip.style.opacity = '1';
+                        }
+                        // --- END INLINED TOOLTIP DISPLAY LOGIC ---
+
+                        // Original clipboard copy logic
                         if (node.dataset.fullText) {
                             navigator.clipboard.writeText(node.dataset.fullText)
                                 .then(() => {


### PR DESCRIPTION
This commit introduces several improvements to enhance the user experience on mobile devices:

- Refined Controls: Adjusted padding for control bar buttons (Download, Help) to be more compact on smaller screens.
- Improved Node Interaction: Modified node click/tap behavior to display tooltips, making full text more accessible on touch devices.
- Help Screen Polish: Adjusted padding for example buttons within the help screen for better visual consistency on mobile.

Other areas reviewed for mobile usability (text input, analysis display, mind map generation, pan/zoom, image download, dark mode) were found to be generally adequate with existing responsive design.